### PR TITLE
chore: make ECMAScript version consistent between TS and ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
 	'env': {
 		'browser': true,
-		'es2021': true,
+		'es2022': true,
 		'node': true,
 	},
 	'extends': [
@@ -12,7 +12,7 @@ module.exports = {
 	],
 	'parser': '@typescript-eslint/parser',
 	'parserOptions': {
-		'ecmaVersion': 2017,
+		'ecmaVersion': 2022,
 		'sourceType': 'module',
 	},
 	'plugins': [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"target": "es2017"
+		"target": "es2022"
 	},
 	"include": [
 		"src/**/*.ts"


### PR DESCRIPTION
Bumps from ES2017 to ES2022.